### PR TITLE
Do not use utcnow() if formatting time as %s

### DIFF
--- a/git_tarballs
+++ b/git_tarballs
@@ -105,7 +105,7 @@ def get_commit_from_spec(package):
 
 def package_version(upstream_version, upstream_commit):
     return '%s+git.%s.%s' % (upstream_version,
-                             datetime.utcnow().strftime('%s'),
+                             datetime.now().strftime('%s'),
                              upstream_commit[:COMMIT_HASH_SIZE])
 
 


### PR DESCRIPTION
%s is already giving time in UTC. If we use utcnow() on top of that,
then we don't get the real time, but a time with a timezone difference.
