### PR TITLE
Keep intact parameters to %setup (except old '-n foo')

### DIFF
--- a/git_tarballs
+++ b/git_tarballs
@@ -140,8 +140,13 @@ def update_spec_file(package_version, tarball_parent_dir, filename):
             contents = re.sub(r'\n((Version:\s+).*)\n',
                               r'\n\g<2>%s\n' % package_version,
                               contents, count=1)
-            contents = re.sub(r'\n((%setup\s+).*)\n',
-                              r'\n\g<2>-q -n %s\n' % tarball_parent_dir,
+            # remove previous "-n foo" from %setup line
+            contents = re.sub(r'\n((%setup(?:\s+\S+)*?)\s*-n\s+\S+(.*))\n',
+                              r'\n\g<2>\g<3>\n',
+                              contents, count=1)
+            # add new "-n foo" from %setup line
+            contents = re.sub(r'\n((%setup.*))\n',
+                              r'\n\g<2> -n %s\n' % tarball_parent_dir,
                               contents, count=1)
             contents = re.sub(r'\n((Source0?:\s+).*)\n',
                               r'\n\g<2>%s\n' % filename,


### PR DESCRIPTION
openstack-keystone has a %setup line like this:
 %setup -q -T -D -b0 -a6 -n keystone-2012.2.3

(this is for the hybrid backend)

We don't want to replace it with:
 %setup -q -n keystone-2012.2.3

So use two regexps: one to remove "-n oldfoo", and then one to add "-n
newfoo". Note that we have to be careful to avoid matching that is too
greedy (to not match on multiline and then eat the -n option from
"%files -n foo").
