### PR TITLE
Fix off-by-one in .changes file template

### DIFF
--- a/git_tarballs
+++ b/git_tarballs
@@ -223,7 +223,7 @@ def create_changes(changes_list, package_version, package_commit, email):
     commits = "  + " + "\n  + ".join(messages)
 
     change = (
-        '--------------------------------------------------------------------'
+        '-------------------------------------------------------------------'
         '\n%(timestamp)s - %(email)s\n'
         '\n'
         '- Update to version %(package_version)s:\n'


### PR DESCRIPTION
The heading of a new changes entry had one '-'
too many.
