### PR TITLE
README.rst: Add links to OBS package and git repo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,7 @@ Up to date requirements are kept in the files ``requirements.txt`` and
 
 Contributing
 ------------
+This is the git repository for `openSUSE\:Tools/obs-service-git_tarballs`_. The authoritative source is https://github.com/openSUSE/obs-service-git_tarballs.
 
 You can submit or ask for improvements using github's Pull Requests or Issues. If you're sending a patch, please make sure the testsuite is still running and also run flake8 on the files you've modified. It would be great if you could also modify this README file to describe new functionality and add tests.
 
@@ -41,3 +42,4 @@ You can take a look at the .travis.yml file to see how the testsuite and flake8 
 
 .. _Open Build Service: http://openbuildservice.org/
 .. _python-mock: http://www.voidspace.org.uk/python/mock/mock.html
+.. _openSUSE\:Tools/obs-service-git_tarballs: https://build.opensuse.org/package/show/openSUSE:Tools/obs-service-git_tarballs


### PR DESCRIPTION
Normalize README files across the various obs-service-* services.